### PR TITLE
feat: parameterize default router nodepool

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -142,6 +142,40 @@ Type: `map(any)`
 
 Default: `null`
 
+==== [[input_router_nodepool]] <<input_router_nodepool,router_nodepool>>
+
+Description: n/a
+
+Type:
+[source,hcl]
+----
+object({
+    size            = optional(number, 2)
+    instance_type   = optional(string, "standard.small")
+    instance_prefix = optional(string, null)
+    disk_size       = optional(number, null)
+    taints = optional(map(string), {
+      nodepool = "router:NoSchedule"
+    })
+    private_network_ids = optional(list(string), null)
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "disk_size": null,
+  "instance_prefix": null,
+  "instance_type": "standard.small",
+  "private_network_ids": null,
+  "size": 2,
+  "taints": {
+    "nodepool": "router:NoSchedule"
+  }
+}
+----
+
 ==== [[input_tcp_node_ports_world_accessible]] <<input_tcp_node_ports_world_accessible,tcp_node_ports_world_accessible>>
 
 Description: Create a security group rule that allows world access to to NodePort TCP services. Recommended to leave open as per https://community.exoscale.com/documentation/sks/quick-start/#creating-a-cluster-from-the-cli[SKS documentation].
@@ -317,6 +351,42 @@ The other keys are optional: `description`, `instance_prefix`, `disk_size`, `lab
 
 |`map(any)`
 |`null`
+|no
+
+|[[input_router_nodepool]] <<input_router_nodepool,router_nodepool>>
+|n/a
+|
+
+[source]
+----
+object({
+    size            = optional(number, 2)
+    instance_type   = optional(string, "standard.small")
+    instance_prefix = optional(string, null)
+    disk_size       = optional(number, null)
+    taints = optional(map(string), {
+      nodepool = "router:NoSchedule"
+    })
+    private_network_ids = optional(list(string), null)
+  })
+----
+
+|
+
+[source]
+----
+{
+  "disk_size": null,
+  "instance_prefix": null,
+  "instance_type": "standard.small",
+  "private_network_ids": null,
+  "size": 2,
+  "taints": {
+    "nodepool": "router:NoSchedule"
+  }
+}
+----
+
 |no
 
 |[[input_tcp_node_ports_world_accessible]] <<input_tcp_node_ports_world_accessible,tcp_node_ports_world_accessible>>

--- a/locals.tf
+++ b/locals.tf
@@ -9,16 +9,15 @@ locals {
   # https://community.exoscale.com/documentation/sks/loadbalancer-ingress/.
   nodepools_defaults = {
     "${var.cluster_name}-router" = {
-      size            = 2
-      instance_type   = "standard.small"
+      size            = var.router_nodepool.size
+      instance_type   = var.router_nodepool.instance_type
       description     = "Router nodepool for ${var.cluster_name} used to avoid loopbacks."
-      instance_prefix = null
-      disk_size       = null
+      instance_prefix = var.router_nodepool.instance_prefix
+      disk_size       = var.router_nodepool.disk_size
 
-      taints = {
-        nodepool = "router:NoSchedule"
-      }
-      private_network_ids = null
+      taints = var.router_nodepool.taints
+
+      private_network_ids = var.router_nodepool.private_network_ids
     },
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,30 @@ variable "nodepools" {
   default     = null
 }
 
+variable "router_nodepool" {
+  description = ""
+  type = object({
+    size            = optional(number, 2)
+    instance_type   = optional(string, "standard.small")
+    instance_prefix = optional(string, null)
+    disk_size       = optional(number, null)
+    taints = optional(map(string), {
+      nodepool = "router:NoSchedule"
+    })
+    private_network_ids = optional(list(string), null)
+  })
+  default = {
+    size            = 2
+    instance_type   = "standard.small"
+    instance_prefix = null
+    disk_size       = null
+    taints = {
+      nodepool = "router:NoSchedule"
+    }
+    private_network_ids = null
+  }
+}
+
 variable "tcp_node_ports_world_accessible" {
   description = "Create a security group rule that allows world access to to NodePort TCP services. Recommended to leave open as per https://community.exoscale.com/documentation/sks/quick-start/#creating-a-cluster-from-the-cli[SKS documentation]."
   type        = bool


### PR DESCRIPTION
## Description of the changes

Currently, router nodepool is fully hardcoded which doesn't allow us to resize this nodepool. For K8S upgrade we need to be able to resize it.
This PR parameterize all settings of this default nodepool in object variable with default values.  

## Breaking change

- [x] No
- [ ] Yes
