### PR TITLE
docs: remove hardcoded version from examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ This module can be used with the following declaration:
 [source,terraform]
 ----
 module "sks" {
-  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-sks.git?ref=v1.0.0"
+  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-sks.git?ref=<RELEASE>"
 
   cluster_name       = local.cluster_name
   kubernetes_version = local.kubernetes_version
@@ -36,7 +36,7 @@ Multiple node pools and with more complex settings can be declared. The followin
 [source,terraform]
 ----
 module "sks" {
-  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-sks.git?ref=v1.0.0"
+  source = "git::https://github.com/camptocamp/devops-stack-module-cluster-sks.git?ref=<RELEASE>"
 
   cluster_name       = local.cluster_name
   kubernetes_version = local.kubernetes_version


### PR DESCRIPTION
## Description of the changes

This is just a small modification of the example on the README.adoc, which contained an hardcoded version. This changes puts the module in line with the other README.adoc from other modules.

## Breaking change

- [x] No
