### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -203,7 +203,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_base_domain]] <<input_base_domain,base_domain>>
 
-Description: The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address.
+Description: The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address.
 
 Type: `string`
 
@@ -211,7 +211,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: The subdomain used for ingresses.
 
 Type: `string`
 
@@ -463,13 +463,13 @@ Description: Raw `.kube/config` file for `kubectl` access.
 |yes
 
 |[[input_base_domain]] <<input_base_domain,base_domain>>
-|The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address.
+|The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address.
 |`string`
 |`null`
 |no
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|The subdomain used for ingresses.
 |`string`
 |`"apps"`
 |no

--- a/README.adoc
+++ b/README.adoc
@@ -209,6 +209,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_description]] <<input_description,description>>
 
 Description: A free-form string description to apply to the SKS cluster.
@@ -235,7 +243,7 @@ Default: `"pro"`
 
 ==== [[input_nodepools]] <<input_nodepools,nodepools>>
 
-Description: Map containing the SKS node pools to create.  
+Description: Map containing the SKS node pools to create.
 
 Needs to be a map of maps, where the key is the name of the node pool and the value is a map containing at least the keys `instance_type` and `size`.  
 The other keys are optional: `description`, `instance_prefix`, `disk_size`, `labels`, `taints` and `private_network_ids`. Check the official documentation https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_nodepool[here] for more information.
@@ -460,6 +468,12 @@ Description: Raw `.kube/config` file for `kubectl` access.
 |`null`
 |no
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_description]] <<input_description,description>>
 |A free-form string description to apply to the SKS cluster.
 |`string`
@@ -492,6 +506,7 @@ Description: Raw `.kube/config` file for `kubectl` access.
 
 |[[input_nodepools]] <<input_nodepools,nodepools>>
 |Map containing the SKS node pools to create.
+
 Needs to be a map of maps, where the key is the name of the node pool and the value is a map containing at least the keys `instance_type` and `size`.
 The other keys are optional: `description`, `instance_prefix`, `disk_size`, `labels`, `taints` and `private_network_ids`. Check the official documentation https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_nodepool[here] for more information.
 

--- a/lb_dns.tf
+++ b/lb_dns.tf
@@ -13,7 +13,7 @@ resource "exoscale_domain_record" "wildcard_with_cluster_name" {
   count = var.base_domain == null ? 0 : 1
 
   domain      = data.exoscale_domain.this[count.index].id
-  name        = format("*.apps.%s", var.cluster_name)
+  name        = format("*.%s", trimprefix("${var.subdomain}.${var.cluster_name}", "."))
   record_type = "A"
   ttl         = "300"
   content     = resource.exoscale_nlb.this.ip_address

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "base_domain" {
   default     = null
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "description" {
   description = "A free-form string description to apply to the SKS cluster."
   type        = string
@@ -40,7 +46,7 @@ variable "service_level" {
 variable "nodepools" {
   description = <<-EOT
   Map containing the SKS node pools to create.
-  
+
   Needs to be a map of maps, where the key is the name of the node pool and the value is a map containing at least the keys `instance_type` and `size`.
   The other keys are optional: `description`, `instance_prefix`, `disk_size`, `labels`, `taints` and `private_network_ids`. Check the official documentation https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_nodepool[here] for more information.
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,7 @@ variable "subdomain" {
   description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "description" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,10 +46,10 @@ variable "service_level" {
 
 variable "nodepools" {
   description = <<-EOT
-  Map containing the SKS node pools to create.
+    Map containing the SKS node pools to create.
 
-  Needs to be a map of maps, where the key is the name of the node pool and the value is a map containing at least the keys `instance_type` and `size`.
-  The other keys are optional: `description`, `instance_prefix`, `disk_size`, `labels`, `taints` and `private_network_ids`. Check the official documentation https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_nodepool[here] for more information.
+    Needs to be a map of maps, where the key is the name of the node pool and the value is a map containing at least the keys `instance_type` and `size`.
+    The other keys are optional: `description`, `instance_prefix`, `disk_size`, `labels`, `taints` and `private_network_ids`. Check the official documentation https://registry.terraform.io/providers/exoscale/exoscale/latest/docs/resources/sks_nodepool[here] for more information.
   EOT
   type = map(object({
     size                = number

--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,13 @@ variable "cluster_name" {
 }
 
 variable "base_domain" {
-  description = "The base domain used for Ingresses. If not provided, nip.io will be used taking the NLB IP address."
+  description = "The base domain used for ingresses. If not provided, nip.io will be used taking the NLB IP address."
   type        = string
   default     = null
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "The subdomain used for ingresses."
   type        = string
   default     = "apps"
 }


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [X] SKS (Exoscale)